### PR TITLE
KIND local dev, lease safety, metrics, and exploratory test fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,62 @@ test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expect
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
+##@ Local Development (KIND)
+
+KIND_DEV_CLUSTER ?= logic-operator-dev
+CERT_MANAGER_VERSION ?= v1.16.3
+CERT_MANAGER_URL ?= https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
+INGRESS_NGINX_VERSION ?= v1.12.2
+INGRESS_NGINX_URL ?= https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-$(INGRESS_NGINX_VERSION)/deploy/static/provider/kind/deploy.yaml
+
+.PHONY: kind-create
+kind-create: ## Create a KIND cluster for local development.
+	@command -v $(KIND) >/dev/null 2>&1 || { \
+		echo "Kind is not installed. Please install Kind: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"; \
+		exit 1; \
+	}
+	@case "$$($(KIND) get clusters)" in \
+		*"$(KIND_DEV_CLUSTER)"*) \
+			echo "Kind cluster '$(KIND_DEV_CLUSTER)' already exists. Skipping creation." ;; \
+		*) \
+			echo "Creating Kind cluster '$(KIND_DEV_CLUSTER)'..."; \
+			$(KIND) create cluster --name $(KIND_DEV_CLUSTER) --config hack/kind-config.yaml; \
+			echo "Installing ingress-nginx..."; \
+			$(KUBECTL) apply -f $(INGRESS_NGINX_URL); \
+			echo "Waiting for ingress-nginx to be ready..."; \
+			$(KUBECTL) wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=120s; \
+			echo "Installing cert-manager $(CERT_MANAGER_VERSION)..."; \
+			$(KUBECTL) apply -f $(CERT_MANAGER_URL); \
+			echo "Waiting for cert-manager to be ready..."; \
+			$(KUBECTL) wait --namespace cert-manager --for=condition=available deployment --all --timeout=120s ;; \
+	esac
+
+KIND_IMG ?= controller:dev
+
+.PHONY: kind-deploy
+kind-deploy: manifests generate kustomize ## Build, load, and deploy the operator into KIND.
+	$(CONTAINER_TOOL) build -t $(KIND_IMG) .
+	$(KIND) load docker-image $(KIND_IMG) --name $(KIND_DEV_CLUSTER)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(KIND_IMG)
+	$(KUSTOMIZE) build config/default | $(KUBECTL) apply --server-side -f -
+	@echo "Waiting for operator deployment to be ready..."
+	@$(KUBECTL) wait --namespace logic-operator-system --for=condition=available deployment --all --timeout=120s
+	@echo "Operator deployed successfully."
+
+.PHONY: kind-demo
+kind-demo: ## Apply sample CRs (Runtime + Definition + Service) to the KIND cluster.
+	$(KUBECTL) apply -k config/samples/
+	@echo "Sample CRs applied. Check status with:"
+	@echo "  kubectl get logicflowruntimes,logicflowdefinitions,logicflowservices"
+
+.PHONY: kind-undemo
+kind-undemo: ## Remove sample CRs from the KIND cluster.
+	$(KUBECTL) delete -k config/samples/ --ignore-not-found=true
+
+.PHONY: kind-delete
+kind-delete: ## Delete the KIND development cluster.
+	$(KIND) delete cluster --name $(KIND_DEV_CLUSTER)
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Logic Operator
 
-A Kubernetes operator for managing serverless logic workflows powered by Quarkus Flow.
+A Kubernetes operator for managing Serverless Logic workflows powered by Quarkus Flow.
 
 ## Description
 
-The Logic Operator provides a Kubernetes-native way to deploy, manage, and scale serverless logic workflows. Built on top of Quarkus Flow, it offers four core CRDs for defining and orchestrating workflow-based applications:
+The Logic Operator provides a Kubernetes-native way to deploy, manage, and scale Serverless Logic workflows. Built on top of Quarkus Flow, it offers four core CRDs for defining and orchestrating workflow-based applications:
 
 - **LogicPlatform**: Platform-wide configuration and shared services
 - **LogicFlowService**: Application definitions for workflow deployments
@@ -16,108 +16,93 @@ This is v2.0 of the operator, representing a complete architectural overhaul wit
 ## Getting Started
 
 ### Prerequisites
-- go version v1.26.0+
-- docker version 17.03+
-- kubectl version v1.11.3+
-- Access to a Kubernetes v1.11.3+ cluster
 
-### To Deploy on the cluster
-**Build and push your image to the location specified by `IMG`:**
+- [Go](https://go.dev/dl/) v1.26+
+- [Docker](https://docs.docker.com/get-docker/) v17.03+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.30+
+- [KIND](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) v0.20+
 
-```sh
-make docker-build docker-push IMG=<some-registry>/logic-operator:tag
-```
+### Quickstart (KIND)
 
-**NOTE:** This image ought to be published in the personal registry you specified.
-And it is required to have access to pull the image from the working environment.
-Make sure you have the proper permission to the registry if the above commands don’t work.
-
-**Install the CRDs into the cluster:**
+Get a fully working operator with sample workflows in three commands:
 
 ```sh
-make install
+make kind-create    # create KIND cluster with ingress-nginx + cert-manager
+make kind-deploy    # build, load, and deploy the operator
+make kind-demo      # apply sample CRs (Runtime + Definition + Service)
 ```
 
-**Deploy the Manager to the cluster with the image specified by `IMG`:**
+Check that everything is running:
 
 ```sh
-make deploy IMG=<some-registry>/logic-operator:tag
+kubectl get logicflowruntimes,logicflowdefinitions,logicflowservices
 ```
 
-> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin
-privileges or be logged in as admin.
-
-**Create instances of your solution**
-You can apply the samples (examples) from the config/sample:
+The sample deploys a `hello-world` workflow you can invoke once the runtime pod is ready:
 
 ```sh
-kubectl apply -k config/samples/
+kubectl wait --for=condition=available deployment/hello-runtime --timeout=120s
+curl -X POST http://hello.lvh.me/ \
+  -H "Content-Type: application/json" \
+  -d ‘{"name": "World"}’
 ```
 
->**NOTE**: Ensure that the samples has default values to test it out.
+> `lvh.me` resolves to `127.0.0.1` — no `/etc/hosts` editing needed.
 
-### To Uninstall
-**Delete the instances (CRs) from the cluster:**
+The runtime is also exposed directly at `http://runtime.lvh.me/` for accessing OpenAPI specs, health checks, and dashboards:
+
+```sh
+curl http://runtime.lvh.me/q/openapi   # OpenAPI spec
+curl http://runtime.lvh.me/q/health    # health checks
+```
+
+Alternatively, you can port-forward the runtime service without ingress:
+
+```sh
+kubectl port-forward svc/hello-runtime 8080:80
+curl http://localhost:8080/q/openapi
+```
+
+To clean up:
+
+```sh
+make kind-undemo    # remove sample CRs
+make kind-delete    # delete the KIND cluster
+```
+
+### Available Make targets
+
+| Target | Description |
+|--------|-------------|
+| `make kind-create` | Create KIND cluster with ingress and cert-manager |
+| `make kind-deploy` | Build image, load into KIND, deploy operator |
+| `make kind-demo` | Apply sample CRs |
+| `make kind-undemo` | Remove sample CRs |
+| `make kind-delete` | Delete the KIND cluster |
+| `make run` | Run the operator out-of-cluster (day-to-day development) |
+| `make test` | Run unit and integration tests |
+| `make lint` | Run golangci-lint |
+| `make test-e2e` | Run end-to-end tests (creates its own cluster) |
+
+Run `make help` for the full list.
+
+### Deploy to an existing cluster
+
+If you already have a Kubernetes cluster with cert-manager installed:
+
+```sh
+make install                                        # install CRDs
+make deploy IMG=<some-registry>/logic-operator:tag  # deploy the operator
+kubectl apply -k config/samples/                    # apply sample CRs
+```
+
+To uninstall:
 
 ```sh
 kubectl delete -k config/samples/
-```
-
-**Delete the APIs(CRDs) from the cluster:**
-
-```sh
+make undeploy
 make uninstall
 ```
-
-**UnDeploy the controller from the cluster:**
-
-```sh
-make undeploy
-```
-
-## Project Distribution
-
-Following the options to release and provide this solution to the users.
-
-### By providing a bundle with all YAML files
-
-1. Build the installer for the image built and published in the registry:
-
-```sh
-make build-installer IMG=<some-registry>/logic-operator:tag
-```
-
-**NOTE:** The makefile target mentioned above generates an 'install.yaml'
-file in the dist directory. This file contains all the resources built
-with Kustomize, which are necessary to install this project without its
-dependencies.
-
-2. Using the installer
-
-Users can just run 'kubectl apply -f <URL for YAML BUNDLE>' to install
-the project, i.e.:
-
-```sh
-kubectl apply -f https://raw.githubusercontent.com/<org>/logic-operator/<tag or branch>/dist/install.yaml
-```
-
-### By providing a Helm Chart
-
-1. Build the chart using the optional helm plugin
-
-```sh
-operator-sdk edit --plugins=helm/v1-alpha
-```
-
-2. See that a chart was generated under 'dist/chart', and users
-can obtain this solution from there.
-
-**NOTE:** If you change the project, you need to update the Helm Chart
-using the same command above to sync the latest changes. Furthermore,
-if you create webhooks, you need to use the above command with
-the '--force' flag and manually ensure that any custom configuration
-previously added to 'dist/chart/values.yaml' or 'dist/chart/manager/manager.yaml'
-is manually re-applied afterwards.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,33 @@ kubectl port-forward svc/hello-runtime 8080:80
 curl http://localhost:8080/q/openapi
 ```
 
+### Enable API-KEY Authentication
+
+To secure the runtime with API-KEY authentication, apply the authentication overlay on top of the demo:
+
+```sh
+kubectl apply -k config/samples/authentication/
+kubectl rollout restart deployment/hello-runtime
+kubectl rollout status deployment/hello-runtime --timeout=120s
+```
+
+Unauthenticated requests are now rejected:
+
+```sh
+curl -s -o /dev/null -w "%{http_code}" -X POST http://hello.lvh.me/ \
+  -H "Content-Type: application/json" -d '{"name": "World"}'
+# 401
+```
+
+Pass the API key as a Bearer token:
+
+```sh
+curl -X POST http://hello.lvh.me/ \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer logic-operator-dev-token" \
+  -d '{"name": "World"}'
+```
+
 To clean up:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The sample deploys a `hello-world` workflow you can invoke once the runtime pod 
 kubectl wait --for=condition=available deployment/hello-runtime --timeout=120s
 curl -X POST http://hello.lvh.me/ \
   -H "Content-Type: application/json" \
-  -d ‘{"name": "World"}’
+  -d '{"name": "World"}'
 ```
 
 > `lvh.me` resolves to `127.0.0.1` — no `/etc/hosts` editing needed.

--- a/README.md
+++ b/README.md
@@ -90,10 +90,44 @@ curl -X POST http://hello.lvh.me/ \
   -d '{"name": "World"}'
 ```
 
+### Enable Persistence (PostgreSQL + Durable Workflows)
+
+Deploy a 3-replica runtime with PostgreSQL persistence and a sleepy workflow for testing durable execution:
+
+```sh
+kubectl apply -k config/samples/persistence/
+```
+
+This creates a PostgreSQL instance, a 3-replica runtime with lease-based sharding, and a `sleepy-workflow` (30s wait task). Test durable recovery:
+
+```sh
+# Fire a workflow
+curl -X POST http://localhost:8080/q/flow/exec/default/sleepy-workflow/1.0.0 \
+  -H "Content-Type: application/json" -d '{"name": "durable-test"}'
+
+# Kill the pod — the workflow resumes on another replica
+kubectl delete pod -l app.kubernetes.io/name=hello-runtime --wait=false
+```
+
+### Enable Monitoring (Prometheus + Grafana)
+
+Deploy Prometheus and Grafana with a pre-configured "Logic Flow Runtime" dashboard:
+
+```sh
+kubectl apply -k config/samples/monitoring/
+```
+
+- **Grafana**: http://grafana.lvh.me (anonymous access, no login required)
+- **Prometheus**: http://prometheus.lvh.me
+
+Open Grafana and navigate to **Dashboards > Logic Operator > Logic Flow Runtime**. The dashboard shows workflow start/completion rates, active instance gauges, task duration histograms, and per-pod distribution. Metrics appear after the first workflow execution.
+
 To clean up:
 
 ```sh
 make kind-undemo    # remove sample CRs
+kubectl delete -k config/samples/monitoring/ --ignore-not-found=true
+kubectl delete -k config/samples/persistence/ --ignore-not-found=true
 make kind-delete    # delete the KIND cluster
 ```
 

--- a/api/v1/logicflowservice_types.go
+++ b/api/v1/logicflowservice_types.go
@@ -209,6 +209,7 @@ type TrafficStatus struct {
 // +kubebuilder:printcolumn:name="Host",type=string,JSONPath=`.spec.ingress.host`
 // +kubebuilder:printcolumn:name="Runtime",type=string,JSONPath=`.status.runtimeRef.name`
 // +kubebuilder:printcolumn:name="TLS",type=boolean,JSONPath=`.spec.ingress.tls.enabled`
+// +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type LogicFlowService struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1/logicflowservice_types.go
+++ b/api/v1/logicflowservice_types.go
@@ -205,7 +205,7 @@ type TrafficStatus struct {
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced,shortName={lfs,flowservice}
+// +kubebuilder:resource:scope=Namespaced,shortName={lfs,flowsvc}
 // +kubebuilder:printcolumn:name="Host",type=string,JSONPath=`.spec.ingress.host`
 // +kubebuilder:printcolumn:name="Runtime",type=string,JSONPath=`.status.runtimeRef.name`
 // +kubebuilder:printcolumn:name="TLS",type=boolean,JSONPath=`.spec.ingress.tls.enabled`

--- a/api/v1/persistence_types.go
+++ b/api/v1/persistence_types.go
@@ -112,14 +112,14 @@ type PersistenceOptionsSpec struct {
 //	    namespace: databases
 //	    port: 5432
 //	    databaseName: logicflow
-//	    databaseSchema: data-index-service
+//	    databaseSchema: workflows
 //
 // Example (using JDBC URL):
 //
 //	postgresql:
 //	  secretRef:
 //	    name: postgres-credentials
-//	  jdbcUrl: "jdbc:postgresql://postgres.databases.svc:5432/logicflow?currentSchema=data-index-service"
+//	  jdbcUrl: "jdbc:postgresql://postgres.databases.svc:5432/logicflow?currentSchema=workflows"
 //
 // +kubebuilder:validation:MinProperties=2
 // +kubebuilder:validation:MaxProperties=2
@@ -130,7 +130,7 @@ type PersistencePostgreSQL struct {
 	// +optional
 	ServiceRef *PostgreSQLServiceOptions `json:"serviceRef,omitempty"`
 	// PostgreSql JDBC URL. Mutually exclusive to serviceRef.
-	// e.g. "jdbc:postgresql://host:port/database?currentSchema=data-index-service"
+	// e.g. "jdbc:postgresql://host:port/database?currentSchema=workflows"
 	// +optional
 	JdbcURL string `json:"jdbcUrl,omitempty"`
 	// TLS configuration for PostgreSQL connections.
@@ -201,7 +201,7 @@ type SQLServiceOptions struct {
 // PostgreSQLServiceOptions use k8s service to configure postgresql jdbc url.
 type PostgreSQLServiceOptions struct {
 	*SQLServiceOptions `json:",inline"`
-	// Schema of postgresql database to be used. Defaults to "data-index-service"
+	// Schema of postgresql database to be used. When empty, the database default schema is used (typically "public").
 	// +optional
 	DatabaseSchema string `json:"databaseSchema,omitempty"`
 }

--- a/config/crd/bases/logic.kubesmarts.org_logicflowruntimes.yaml
+++ b/config/crd/bases/logic.kubesmarts.org_logicflowruntimes.yaml
@@ -1421,7 +1421,7 @@ spec:
                       jdbcUrl:
                         description: |-
                           PostgreSql JDBC URL. Mutually exclusive to serviceRef.
-                          e.g. "jdbc:postgresql://host:port/database?currentSchema=data-index-service"
+                          e.g. "jdbc:postgresql://host:port/database?currentSchema=workflows"
                         type: string
                       secretRef:
                         description: Secret reference to the database user credentials
@@ -1448,7 +1448,8 @@ spec:
                             type: string
                           databaseSchema:
                             description: Schema of postgresql database to be used.
-                              Defaults to "data-index-service"
+                              When empty, the database default schema is used (typically
+                              "public").
                             type: string
                           name:
                             description: Name of the postgresql k8s service.

--- a/config/crd/bases/logic.kubesmarts.org_logicflowservices.yaml
+++ b/config/crd/bases/logic.kubesmarts.org_logicflowservices.yaml
@@ -13,7 +13,7 @@ spec:
     plural: logicflowservices
     shortNames:
     - lfs
-    - flowservice
+    - flowsvc
     singular: logicflowservice
   scope: Namespaced
   versions:

--- a/config/crd/bases/logic.kubesmarts.org_logicflowservices.yaml
+++ b/config/crd/bases/logic.kubesmarts.org_logicflowservices.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .spec.ingress.tls.enabled
       name: TLS
       type: boolean
+    - jsonPath: .status.url
+      name: URL
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/logic.kubesmarts.org_logicplatforms.yaml
+++ b/config/crd/bases/logic.kubesmarts.org_logicplatforms.yaml
@@ -11033,7 +11033,7 @@ spec:
                           jdbcUrl:
                             description: |-
                               PostgreSql JDBC URL. Mutually exclusive to serviceRef.
-                              e.g. "jdbc:postgresql://host:port/database?currentSchema=data-index-service"
+                              e.g. "jdbc:postgresql://host:port/database?currentSchema=workflows"
                             type: string
                           secretRef:
                             description: Secret reference to the database user credentials
@@ -11060,7 +11060,8 @@ spec:
                                 type: string
                               databaseSchema:
                                 description: Schema of postgresql database to be used.
-                                  Defaults to "data-index-service"
+                                  When empty, the database default schema is used
+                                  (typically "public").
                                 type: string
                               name:
                                 description: Name of the postgresql k8s service.
@@ -12511,7 +12512,7 @@ spec:
                           jdbcUrl:
                             description: |-
                               PostgreSql JDBC URL. Mutually exclusive to serviceRef.
-                              e.g. "jdbc:postgresql://host:port/database?currentSchema=data-index-service"
+                              e.g. "jdbc:postgresql://host:port/database?currentSchema=workflows"
                             type: string
                           secretRef:
                             description: Secret reference to the database user credentials
@@ -12538,7 +12539,8 @@ spec:
                                 type: string
                               databaseSchema:
                                 description: Schema of postgresql database to be used.
-                                  Defaults to "data-index-service"
+                                  When empty, the database default schema is used
+                                  (typically "public").
                                 type: string
                               name:
                                 description: Name of the postgresql k8s service.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: example.com/logic-operator
-  newTag: v0.0.1
+  newName: controller
+  newTag: dev

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
@@ -48,6 +56,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - gateway.networking.k8s.io

--- a/config/samples/authentication/api-key-secret.yaml
+++ b/config/samples/authentication/api-key-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dev-api-key
+stringData:
+  value: "logic-operator-dev-token"

--- a/config/samples/authentication/kustomization.yaml
+++ b/config/samples/authentication/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- api-key-secret.yaml
+- logic_v1_logicflowruntime.yaml

--- a/config/samples/authentication/logic_v1_logicflowruntime.yaml
+++ b/config/samples/authentication/logic_v1_logicflowruntime.yaml
@@ -1,0 +1,17 @@
+apiVersion: logic.kubesmarts.org/v1
+kind: LogicFlowRuntime
+metadata:
+  labels:
+    app.kubernetes.io/name: logic-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: hello-runtime
+spec:
+  security:
+    type: API_KEY
+    apiKey:
+      keys:
+        - name: dev-key
+          secretRef:
+            name: dev-api-key
+          roles:
+            - flow-invoker

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - logic_v1_logicflowservice.yaml
 - logic_v1_logicflowdefinition.yaml
 - logic_v1_logicflowruntime.yaml
+- runtime_ingress.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/logic_v1_logicflowservice.yaml
+++ b/config/samples/logic_v1_logicflowservice.yaml
@@ -4,6 +4,10 @@ metadata:
   labels:
     app.kubernetes.io/name: logic-operator
     app.kubernetes.io/managed-by: kustomize
-  name: logicflowservice-sample
+  name: hello-world
 spec:
-  # TODO(user): Add fields here
+  defaultDefinition:
+    name: hello-world-v1-0-0
+  ingress:
+    host: hello.lvh.me
+    ingressClassName: nginx

--- a/config/samples/monitoring/grafana.yaml
+++ b/config/samples/monitoring/grafana.yaml
@@ -1,0 +1,250 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-provider
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: default
+        folder: Logic Operator
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-workflows
+data:
+  workflows.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "title": "Workflows Started (rate/min)",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+          "targets": [
+            {
+              "expr": "sum(rate(quarkus_flow_workflow_started_total[1m])) by (workflow)",
+              "legendFormat": "{{workflow}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {"unit": "ops", "custom": {"drawStyle": "line", "fillOpacity": 10}},
+            "overrides": []
+          }
+        },
+        {
+          "title": "Workflows Completed (rate/min)",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+          "targets": [
+            {
+              "expr": "sum(rate(quarkus_flow_workflow_completed_total[1m])) by (workflow)",
+              "legendFormat": "{{workflow}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {"unit": "ops", "custom": {"drawStyle": "line", "fillOpacity": 10}},
+            "overrides": []
+          }
+        },
+        {
+          "title": "Active Instances",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 8, "x": 0, "y": 8},
+          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+          "targets": [
+            {"expr": "sum(quarkus_flow_instance_running)", "legendFormat": "Running"},
+            {"expr": "sum(quarkus_flow_instance_waiting)", "legendFormat": "Waiting"},
+            {"expr": "sum(quarkus_flow_instance_suspended)", "legendFormat": "Suspended"}
+          ],
+          "options": {"graphMode": "area", "colorMode": "background_solid"},
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": [
+              {"matcher": {"id": "byName", "options": "Running"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "Waiting"}, "properties": [{"id": "color", "value": {"fixedColor": "yellow", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "Suspended"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]}
+            ]
+          }
+        },
+        {
+          "title": "Total Started / Completed / Faulted",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 8, "x": 8, "y": 8},
+          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+          "targets": [
+            {"expr": "sum(quarkus_flow_workflow_started_total) or vector(0)", "legendFormat": "Started"},
+            {"expr": "sum(quarkus_flow_workflow_completed_total) or vector(0)", "legendFormat": "Completed"},
+            {"expr": "sum(quarkus_flow_workflow_faulted_total) or vector(0)", "legendFormat": "Faulted"}
+          ],
+          "options": {"graphMode": "none", "colorMode": "background_solid"},
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": [
+              {"matcher": {"id": "byName", "options": "Started"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "Completed"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "Faulted"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]}
+            ]
+          }
+        },
+        {
+          "title": "Workflows per Pod",
+          "type": "timeseries",
+          "gridPos": {"h": 4, "w": 8, "x": 16, "y": 8},
+          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+          "targets": [
+            {
+              "expr": "sum(quarkus_flow_workflow_started_total) by (pod)",
+              "legendFormat": "{{pod}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {"custom": {"drawStyle": "bars", "fillOpacity": 50}},
+            "overrides": []
+          }
+        },
+        {
+          "title": "Task Duration (p95)",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(quarkus_flow_task_duration_seconds_bucket[5m])) by (le, task))",
+              "legendFormat": "{{task}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}},
+            "overrides": []
+          }
+        },
+        {
+          "title": "Workflow Duration (p95)",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(quarkus_flow_workflow_duration_seconds_bucket[5m])) by (le, workflow))",
+              "legendFormat": "{{workflow}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}},
+            "overrides": []
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["logic-operator", "quarkus-flow"],
+      "templating": {"list": []},
+      "time": {"from": "now-15m", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Logic Flow Runtime",
+      "uid": "logic-flow-runtime"
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.6.0
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Admin
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: admin
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: dashboards-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboard-workflows
+              mountPath: /var/lib/grafana/dashboards
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboards-provider
+          configMap:
+            name: grafana-dashboards-provider
+        - name: dashboard-workflows
+          configMap:
+            name: grafana-dashboard-workflows
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: grafana.lvh.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000

--- a/config/samples/monitoring/grafana.yaml
+++ b/config/samples/monitoring/grafana.yaml
@@ -35,129 +35,106 @@ data:
     {
       "annotations": {"list": []},
       "editable": true,
-      "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
-      "links": [],
+      "refresh": "10s",
       "panels": [
         {
-          "title": "Workflows Started (rate/min)",
-          "type": "timeseries",
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
-          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
-          "targets": [
-            {
-              "expr": "sum(rate(quarkus_flow_workflow_started_total[1m])) by (workflow)",
-              "legendFormat": "{{workflow}}"
-            }
-          ],
-          "fieldConfig": {
-            "defaults": {"unit": "ops", "custom": {"drawStyle": "line", "fillOpacity": 10}},
-            "overrides": []
-          }
-        },
-        {
-          "title": "Workflows Completed (rate/min)",
-          "type": "timeseries",
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
-          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
-          "targets": [
-            {
-              "expr": "sum(rate(quarkus_flow_workflow_completed_total[1m])) by (workflow)",
-              "legendFormat": "{{workflow}}"
-            }
-          ],
-          "fieldConfig": {
-            "defaults": {"unit": "ops", "custom": {"drawStyle": "line", "fillOpacity": 10}},
-            "overrides": []
-          }
-        },
-        {
-          "title": "Active Instances",
+          "id": 1,
+          "title": "Running",
           "type": "stat",
-          "gridPos": {"h": 4, "w": 8, "x": 0, "y": 8},
-          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
-          "targets": [
-            {"expr": "sum(quarkus_flow_instance_running)", "legendFormat": "Running"},
-            {"expr": "sum(quarkus_flow_instance_waiting)", "legendFormat": "Waiting"},
-            {"expr": "sum(quarkus_flow_instance_suspended)", "legendFormat": "Suspended"}
-          ],
-          "options": {"graphMode": "area", "colorMode": "background_solid"},
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": [
-              {"matcher": {"id": "byName", "options": "Running"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
-              {"matcher": {"id": "byName", "options": "Waiting"}, "properties": [{"id": "color", "value": {"fixedColor": "yellow", "mode": "fixed"}}]},
-              {"matcher": {"id": "byName", "options": "Suspended"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]}
-            ]
-          }
+          "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+          "targets": [{"expr": "sum(quarkus_flow_instance_running) or vector(0)", "instant": true}],
+          "options": {"graphMode": "area", "colorMode": "background_solid", "reduceOptions": {"calcs": ["lastNotNull"]}},
+          "fieldConfig": {"defaults": {"color": {"fixedColor": "green", "mode": "fixed"}, "noValue": "0"}}
         },
         {
-          "title": "Total Started / Completed / Faulted",
+          "id": 2,
+          "title": "Waiting",
           "type": "stat",
-          "gridPos": {"h": 4, "w": 8, "x": 8, "y": 8},
-          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
-          "targets": [
-            {"expr": "sum(quarkus_flow_workflow_started_total) or vector(0)", "legendFormat": "Started"},
-            {"expr": "sum(quarkus_flow_workflow_completed_total) or vector(0)", "legendFormat": "Completed"},
-            {"expr": "sum(quarkus_flow_workflow_faulted_total) or vector(0)", "legendFormat": "Faulted"}
-          ],
-          "options": {"graphMode": "none", "colorMode": "background_solid"},
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": [
-              {"matcher": {"id": "byName", "options": "Started"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]},
-              {"matcher": {"id": "byName", "options": "Completed"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
-              {"matcher": {"id": "byName", "options": "Faulted"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]}
-            ]
-          }
+          "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+          "targets": [{"expr": "sum(quarkus_flow_instance_waiting) or vector(0)", "instant": true}],
+          "options": {"graphMode": "area", "colorMode": "background_solid", "reduceOptions": {"calcs": ["lastNotNull"]}},
+          "fieldConfig": {"defaults": {"color": {"fixedColor": "yellow", "mode": "fixed"}, "noValue": "0"}}
         },
         {
-          "title": "Workflows per Pod",
+          "id": 3,
+          "title": "Suspended",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 4, "x": 8, "y": 0},
+          "targets": [{"expr": "sum(quarkus_flow_instance_suspended) or vector(0)", "instant": true}],
+          "options": {"graphMode": "area", "colorMode": "background_solid", "reduceOptions": {"calcs": ["lastNotNull"]}},
+          "fieldConfig": {"defaults": {"color": {"fixedColor": "orange", "mode": "fixed"}, "noValue": "0"}}
+        },
+        {
+          "id": 4,
+          "title": "Started",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
+          "targets": [{"expr": "sum(quarkus_flow_workflow_started_total) or vector(0)", "instant": true}],
+          "options": {"graphMode": "none", "colorMode": "background_solid", "reduceOptions": {"calcs": ["lastNotNull"]}},
+          "fieldConfig": {"defaults": {"color": {"fixedColor": "blue", "mode": "fixed"}, "noValue": "0"}}
+        },
+        {
+          "id": 5,
+          "title": "Completed",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
+          "targets": [{"expr": "sum(quarkus_flow_workflow_completed_total) or vector(0)", "instant": true}],
+          "options": {"graphMode": "none", "colorMode": "background_solid", "reduceOptions": {"calcs": ["lastNotNull"]}},
+          "fieldConfig": {"defaults": {"color": {"fixedColor": "green", "mode": "fixed"}, "noValue": "0"}}
+        },
+        {
+          "id": 6,
+          "title": "Faulted",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 4, "x": 20, "y": 0},
+          "targets": [{"expr": "sum(quarkus_flow_workflow_faulted_total) or vector(0)", "instant": true}],
+          "options": {"graphMode": "none", "colorMode": "background_solid", "reduceOptions": {"calcs": ["lastNotNull"]}},
+          "fieldConfig": {"defaults": {"color": {"fixedColor": "red", "mode": "fixed"}, "noValue": "0"}}
+        },
+        {
+          "id": 7,
+          "title": "Workflow Throughput (per second)",
           "type": "timeseries",
-          "gridPos": {"h": 4, "w": 8, "x": 16, "y": 8},
-          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
           "targets": [
-            {
-              "expr": "sum(quarkus_flow_workflow_started_total) by (pod)",
-              "legendFormat": "{{pod}}"
-            }
+            {"expr": "sum(rate(quarkus_flow_workflow_started_total[1m])) by (workflow)", "legendFormat": "started: {{workflow}}"},
+            {"expr": "sum(rate(quarkus_flow_workflow_completed_total[1m])) by (workflow)", "legendFormat": "completed: {{workflow}}"}
           ],
-          "fieldConfig": {
-            "defaults": {"custom": {"drawStyle": "bars", "fillOpacity": 50}},
-            "overrides": []
-          }
+          "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "fillOpacity": 10, "pointSize": 5, "showPoints": "auto"}}}
         },
         {
+          "id": 8,
+          "title": "Active Instances Over Time",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+          "targets": [
+            {"expr": "sum(quarkus_flow_instance_running) by (workflow)", "legendFormat": "running: {{workflow}}"},
+            {"expr": "sum(quarkus_flow_instance_waiting) by (workflow)", "legendFormat": "waiting: {{workflow}}"},
+            {"expr": "sum(quarkus_flow_instance_suspended) by (workflow)", "legendFormat": "suspended: {{workflow}}"}
+          ],
+          "fieldConfig": {"defaults": {"custom": {"drawStyle": "line", "fillOpacity": 20, "stacking": {"mode": "normal"}, "pointSize": 5, "showPoints": "auto"}}}
+        },
+        {
+          "id": 9,
           "title": "Task Duration (p95)",
           "type": "timeseries",
           "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
-          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
           "targets": [
-            {
-              "expr": "histogram_quantile(0.95, sum(rate(quarkus_flow_task_duration_seconds_bucket[5m])) by (le, task))",
-              "legendFormat": "{{task}}"
-            }
+            {"expr": "histogram_quantile(0.95, sum(rate(quarkus_flow_task_duration_seconds_bucket[5m])) by (le, task))", "legendFormat": "{{task}}"}
           ],
-          "fieldConfig": {
-            "defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}},
-            "overrides": []
-          }
+          "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}}
         },
         {
-          "title": "Workflow Duration (p95)",
-          "type": "timeseries",
+          "id": 10,
+          "title": "Workflows per Pod",
+          "type": "barchart",
           "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
-          "datasource": {"type": "prometheus", "uid": "PBFA97CFB590B2093"},
           "targets": [
-            {
-              "expr": "histogram_quantile(0.95, sum(rate(quarkus_flow_workflow_duration_seconds_bucket[5m])) by (le, workflow))",
-              "legendFormat": "{{workflow}}"
-            }
+            {"expr": "sum(quarkus_flow_workflow_started_total) by (pod)", "legendFormat": "{{pod}}", "instant": true}
           ],
-          "fieldConfig": {
-            "defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}},
-            "overrides": []
-          }
+          "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}}},
+          "options": {"orientation": "horizontal", "showValue": "always", "xTickLabelRotation": 0}
         }
       ],
       "schemaVersion": 39,

--- a/config/samples/monitoring/kustomization.yaml
+++ b/config/samples/monitoring/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - prometheus.yaml
+  - grafana.yaml

--- a/config/samples/monitoring/prometheus.yaml
+++ b/config/samples/monitoring/prometheus.yaml
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 10s
+    scrape_configs:
+      - job_name: logic-flow-runtime
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_managed_by]
+            action: keep
+            regex: logic-operator
+          - source_labels: [__address__]
+            target_label: __address__
+            regex: ([^:]+)(?::\d+)?
+            replacement: ${1}:8080
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+            target_label: runtime
+        metrics_path: /q/metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v3.4.1
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.retention.time=1h
+            - --storage.tsdb.path=/prometheus
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: prometheus.lvh.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus
+                port:
+                  number: 9090

--- a/config/samples/persistence/kustomization.yaml
+++ b/config/samples/persistence/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - postgresql.yaml
 - logic_v1_logicflowruntime.yaml
 - logic_v1_logicflowdefinition_sleepy.yaml
+- logic_v1_logicflowservice_sleepy.yaml

--- a/config/samples/persistence/kustomization.yaml
+++ b/config/samples/persistence/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- postgresql.yaml
+- logic_v1_logicflowruntime.yaml
+- logic_v1_logicflowdefinition_sleepy.yaml

--- a/config/samples/persistence/logic_v1_logicflowdefinition_sleepy.yaml
+++ b/config/samples/persistence/logic_v1_logicflowdefinition_sleepy.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: logic-operator
     app.kubernetes.io/managed-by: kustomize
-  name: hello-world-v1-0-0
+  name: sleepy-workflow-v1-0-0
 spec:
   runtimeRef:
     name: hello-runtime
@@ -12,9 +12,15 @@ spec:
     document:
       dsl: '1.0.0'
       namespace: examples
-      name: hello-world
+      name: sleepy-workflow
       version: '1.0.0'
     do:
       - greet:
           set:
-            message: '${ "Hi, " + .name + "!" }'
+            message: '${ "Hello, " + .name + "! Sleeping for 30s..." }'
+      - nap:
+          wait:
+            seconds: 30
+      - wakeUp:
+          set:
+            message: '${ "Done! " + .name + " woke up after sleeping." }'

--- a/config/samples/persistence/logic_v1_logicflowruntime.yaml
+++ b/config/samples/persistence/logic_v1_logicflowruntime.yaml
@@ -1,0 +1,16 @@
+apiVersion: logic.kubesmarts.org/v1
+kind: LogicFlowRuntime
+metadata:
+  labels:
+    app.kubernetes.io/name: logic-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: hello-runtime
+spec:
+  replicas: 3
+  persistence:
+    postgresql:
+      secretRef:
+        name: postgresql-secret
+      serviceRef:
+        name: postgresql
+        databaseName: logicflow

--- a/config/samples/persistence/logic_v1_logicflowservice_sleepy.yaml
+++ b/config/samples/persistence/logic_v1_logicflowservice_sleepy.yaml
@@ -1,0 +1,13 @@
+apiVersion: logic.kubesmarts.org/v1
+kind: LogicFlowService
+metadata:
+  labels:
+    app.kubernetes.io/name: logic-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: sleepy-workflow
+spec:
+  defaultDefinition:
+    name: sleepy-workflow-v1-0-0
+  ingress:
+    host: sleepy.lvh.me
+    ingressClassName: nginx

--- a/config/samples/persistence/postgresql.yaml
+++ b/config/samples/persistence/postgresql.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-secret
+type: Opaque
+stringData:
+  POSTGRESQL_USER: flowuser
+  POSTGRESQL_PASSWORD: flowpass
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    app: postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secret
+                  key: POSTGRESQL_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secret
+                  key: POSTGRESQL_PASSWORD
+            - name: POSTGRES_DB
+              value: logicflow
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgresql-storage
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U $POSTGRES_USER -d logicflow
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+      volumes:
+        - name: postgresql-storage
+          persistentVolumeClaim:
+            claimName: postgresql-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    app: postgresql
+spec:
+  selector:
+    app: postgresql
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/config/samples/runtime_ingress.yaml
+++ b/config/samples/runtime_ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hello-runtime
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: runtime.lvh.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hello-runtime
+                port:
+                  number: 80

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP

--- a/internal/controller/integration_test.go
+++ b/internal/controller/integration_test.go
@@ -10,7 +10,6 @@ import (
 	logicv1 "github.com/kubesmarts/logic-operator/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -256,23 +255,25 @@ var _ = Describe("Cross-controller integration", func() {
 		})
 
 		It("should only mount the valid Definition's ConfigMap", func() {
-			// The invalid Definition's reconcile should set RuntimeRefValid=False and not create a ConfigMap
+			// The invalid Definition's reconcile sets RuntimeRefValid=False but still creates a ConfigMap
+			// (ConfigMap apply happens before runtimeRef validation).
+			// The ConfigMap's LabelRuntimeRef points to "nonexistent-runtime", so the real runtime ignores it.
 			invalidDef := reconcileDefAndFetch(ctx, defRec, invalidDefNN)
 			rtCond := meta.FindStatusCondition(invalidDef.Status.Conditions, logicv1.ConditionRuntimeRefValid)
 			Expect(rtCond).NotTo(BeNil())
 			Expect(rtCond.Status).To(Equal(metav1.ConditionFalse))
 
-			// No ConfigMap created for the invalid definition
+			// ConfigMap exists but its LabelRuntimeRef is "nonexistent-runtime"
 			invalidCmNN := types.NamespacedName{Name: ConfigMapPrefix + invalidDefName, Namespace: testNamespace}
 			var cm corev1.ConfigMap
-			err := k8sClient.Get(ctx, invalidCmNN, &cm)
-			Expect(errors.IsNotFound(err)).To(BeTrue())
+			Expect(k8sClient.Get(ctx, invalidCmNN, &cm)).To(Succeed())
+			Expect(cm.Labels[logicv1.LabelRuntimeRef]).To(Equal("nonexistent-runtime"))
 
 			// Valid Definition creates its ConfigMap
 			validDef := reconcileDefAndFetch(ctx, defRec, validDefNN)
 			Expect(validDef.Status.ConfigMapRef).NotTo(BeNil())
 
-			// Runtime only sees the valid one
+			// Runtime only sees the valid one (filters by LabelRuntimeRef matching its own name)
 			rt := reconcileAndFetch(ctx, rtRec, rtNN)
 			Expect(rt.Status.Definitions).To(HaveLen(1))
 			Expect(rt.Status.Definitions[0].Name).To(Equal("valid-flow"))

--- a/internal/controller/logicflowdefinition_controller.go
+++ b/internal/controller/logicflowdefinition_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	logicv1 "github.com/kubesmarts/logic-operator/api/v1"
 	"github.com/open-workflow-specification/sdk-go/v4/model"
@@ -58,19 +59,6 @@ func (r *LogicFlowDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Validate runtimeRef exists
-	var rt logicv1.LogicFlowRuntime
-	rtKey := client.ObjectKey{Name: def.Spec.RuntimeRef.Name, Namespace: def.Namespace}
-	if err := r.Get(ctx, rtKey, &rt); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("referenced LogicFlowRuntime not found", "runtimeRef", def.Spec.RuntimeRef.Name)
-			logicv1.SetCondition(&def.Status.Conditions, logicv1.ConditionRuntimeRefValid, metav1.ConditionFalse, def.Generation, logicv1.ReasonRuntimeNotFound, fmt.Sprintf("LogicFlowRuntime %q not found", def.Spec.RuntimeRef.Name))
-			return ctrl.Result{}, r.Status().Update(ctx, &def)
-		}
-		return ctrl.Result{}, err
-	}
-	logicv1.SetCondition(&def.Status.Conditions, logicv1.ConditionRuntimeRefValid, metav1.ConditionTrue, def.Generation, logicv1.ReasonReady, "")
-
 	// Parse flow document
 	wf, err := def.Spec.ParseFlow()
 	if err != nil {
@@ -83,7 +71,7 @@ func (r *LogicFlowDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.
 	if changed, err := r.updateFlowIDLabels(ctx, &def, wf); err != nil {
 		return ctrl.Result{}, err
 	} else if changed {
-		return ctrl.Result{}, r.updateStatus(ctx, &def, wf)
+		return ctrl.Result{RequeueAfter: time.Second * 3}, r.updateStatus(ctx, &def, wf)
 	}
 
 	conflict, err := r.checkRuntimeConsistency(ctx, &def, wf)
@@ -98,6 +86,19 @@ func (r *LogicFlowDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.
 			logicv1.SetCondition(&def.Status.Conditions, logicv1.ConditionConfigMapReady, metav1.ConditionTrue, def.Generation, logicv1.ReasonReady, "")
 		}
 	}
+
+	// Validate runtimeRef exists
+	var rt logicv1.LogicFlowRuntime
+	rtKey := client.ObjectKey{Name: def.Spec.RuntimeRef.Name, Namespace: def.Namespace}
+	if err := r.Get(ctx, rtKey, &rt); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("referenced LogicFlowRuntime not found", "runtimeRef", def.Spec.RuntimeRef.Name)
+			logicv1.SetCondition(&def.Status.Conditions, logicv1.ConditionRuntimeRefValid, metav1.ConditionFalse, def.Generation, logicv1.ReasonRuntimeNotFound, fmt.Sprintf("LogicFlowRuntime %q not found", def.Spec.RuntimeRef.Name))
+			return ctrl.Result{RequeueAfter: time.Second * 30}, r.updateStatus(ctx, &def, wf)
+		}
+		return ctrl.Result{}, err
+	}
+	logicv1.SetCondition(&def.Status.Conditions, logicv1.ConditionRuntimeRefValid, metav1.ConditionTrue, def.Generation, logicv1.ReasonReady, "")
 
 	return ctrl.Result{}, r.updateStatus(ctx, &def, wf)
 }

--- a/internal/controller/logicflowdefinition_controller_test.go
+++ b/internal/controller/logicflowdefinition_controller_test.go
@@ -211,22 +211,32 @@ var _ = Describe("LogicFlowDefinition Controller", func() {
 			deleteDefinition(ctx, defNN)
 		})
 
-		It("should not create a ConfigMap", func() {
+		It("should still create a ConfigMap even without the runtime", func() {
 			reconcileDefAndFetch(ctx, r, defNN)
 
 			var cm corev1.ConfigMap
 			cmNN := types.NamespacedName{Name: ConfigMapPrefix + defName, Namespace: testNamespace}
-			err := k8sClient.Get(ctx, cmNN, &cm)
-			Expect(errors.IsNotFound(err)).To(BeTrue())
+			Expect(k8sClient.Get(ctx, cmNN, &cm)).To(Succeed())
 		})
 
-		It("should set RuntimeRefValid condition to False", func() {
+		It("should set RuntimeRefValid condition to False and requeue", func() {
 			def := reconcileDefAndFetch(ctx, r, defNN)
 
 			rtCond := meta.FindStatusCondition(def.Status.Conditions, logicv1.ConditionRuntimeRefValid)
 			Expect(rtCond).NotTo(BeNil())
 			Expect(rtCond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(rtCond.Reason).To(Equal(logicv1.ReasonRuntimeNotFound))
+		})
+
+		It("should return RequeueAfter when runtime is missing", func() {
+			r := newDefReconciler()
+			// First reconcile sets labels
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: defNN})
+			Expect(err).NotTo(HaveOccurred())
+			// Second reconcile applies ConfigMap and hits missing runtime
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: defNN})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 		})
 	})
 
@@ -265,12 +275,11 @@ var _ = Describe("LogicFlowDefinition Controller", func() {
 			Expect(flowCond.Reason).To(Equal(logicv1.ReasonParseError))
 		})
 
-		It("should set RuntimeRefValid to True (runtime exists)", func() {
+		It("should not set RuntimeRefValid condition (short-circuits before runtime check)", func() {
 			def := reconcileDefAndFetch(ctx, r, defNN)
 
 			rtCond := meta.FindStatusCondition(def.Status.Conditions, logicv1.ConditionRuntimeRefValid)
-			Expect(rtCond).NotTo(BeNil())
-			Expect(rtCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(rtCond).To(BeNil())
 		})
 	})
 

--- a/internal/controller/logicflowruntime_controller.go
+++ b/internal/controller/logicflowruntime_controller.go
@@ -119,6 +119,7 @@ func (r *LogicFlowRuntimeReconciler) applyDeployment(ctx context.Context, rt *lo
 		DefaultRunnerImage(rt.Spec.Persistence),
 		WithPersistenceEnvVars(rt.Spec.Persistence, rt.Namespace),
 		WithSecurityEnvVars(rt.Spec.Security),
+		WithMetricsEnvVars(),
 		DefaultProbes(),
 		WithFlowSourcePath(),
 		WithFlowVolumeMounts(configMaps),

--- a/internal/controller/logicflowruntime_controller.go
+++ b/internal/controller/logicflowruntime_controller.go
@@ -53,7 +53,8 @@ type LogicFlowRuntimeReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
-// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;delete
 
@@ -148,6 +149,8 @@ func (r *LogicFlowRuntimeReconciler) applyDeployment(ctx context.Context, rt *lo
 }
 
 func (r *LogicFlowRuntimeReconciler) reconcileLeases(ctx context.Context, rt *logicv1.LogicFlowRuntime) error {
+	log := logf.FromContext(ctx)
+
 	if rt.Spec.Persistence == nil {
 		return nil
 	}
@@ -164,6 +167,11 @@ func (r *LogicFlowRuntimeReconciler) reconcileLeases(ctx context.Context, rt *lo
 		client.InNamespace(rt.Namespace),
 		client.MatchingLabels{LabelDurablePool: rt.Name},
 	); err != nil {
+		return err
+	}
+
+	runningPods, err := r.runningPodNames(ctx, rt)
+	if err != nil {
 		return err
 	}
 
@@ -189,6 +197,12 @@ func (r *LogicFlowRuntimeReconciler) reconcileLeases(ctx context.Context, rt *lo
 
 	for i := range leaseList.Items {
 		if _, ok := desiredNames[leaseList.Items[i].Name]; !ok {
+			if leaseHeldByRunningPod(&leaseList.Items[i], runningPods) {
+				log.V(1).Info("skipping deletion of lease held by running pod",
+					"lease", leaseList.Items[i].Name,
+					"holder", *leaseList.Items[i].Spec.HolderIdentity)
+				continue
+			}
 			if err := r.Delete(ctx, &leaseList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
@@ -196,6 +210,31 @@ func (r *LogicFlowRuntimeReconciler) reconcileLeases(ctx context.Context, rt *lo
 	}
 
 	return nil
+}
+
+func (r *LogicFlowRuntimeReconciler) runningPodNames(ctx context.Context, rt *logicv1.LogicFlowRuntime) (map[string]struct{}, error) {
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList,
+		client.InNamespace(rt.Namespace),
+		client.MatchingLabels(SelectorLabels(rt.Name)),
+	); err != nil {
+		return nil, err
+	}
+	names := make(map[string]struct{}, len(podList.Items))
+	for i := range podList.Items {
+		if podList.Items[i].DeletionTimestamp == nil {
+			names[podList.Items[i].Name] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
+func leaseHeldByRunningPod(lease *coordinationv1.Lease, runningPods map[string]struct{}) bool {
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+		return false
+	}
+	_, held := runningPods[*lease.Spec.HolderIdentity]
+	return held
 }
 
 func (r *LogicFlowRuntimeReconciler) reconcilePodRBAC(ctx context.Context, rt *logicv1.LogicFlowRuntime) error {

--- a/internal/controller/logicflowruntime_controller_test.go
+++ b/internal/controller/logicflowruntime_controller_test.go
@@ -365,6 +365,10 @@ var _ = Describe("LogicFlowRuntime Controller", func() {
 			rolesEnv := findEnvVar(envs, `QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__"svc-key"__ROLES`)
 			Expect(rolesEnv).NotTo(BeNil())
 			Expect(rolesEnv.Value).To(Equal("flow-admin"))
+
+			nsEnv := findEnvVar(envs, `QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__"svc-key"__NAMESPACES`)
+			Expect(nsEnv).NotTo(BeNil())
+			Expect(nsEnv.Value).To(Equal("*"))
 		})
 	})
 
@@ -893,7 +897,7 @@ var _ = Describe("LogicFlowRuntime Controller", func() {
 			Expect(rt2.Status.LeaseReplicas).To(Equal(int32(3)))
 		})
 
-		It("should delete excess leases on scale down", func() {
+		It("should delete unheld excess leases on scale down", func() {
 			var rt logicv1.LogicFlowRuntime
 			Expect(k8sClient.Get(ctx, nn, &rt)).To(Succeed())
 			replicas := int32(3)
@@ -912,6 +916,52 @@ var _ = Describe("LogicFlowRuntime Controller", func() {
 			Expect(leases).To(HaveLen(1))
 			Expect(leases[0].Name).To(Equal(fmt.Sprintf(LeaseMemberNameFmt, name, 0)))
 			Expect(rt2.Status.LeaseReplicas).To(Equal(int32(1)))
+		})
+
+		It("should not delete a lease held by a running pod on scale down", func() {
+			var rt logicv1.LogicFlowRuntime
+			Expect(k8sClient.Get(ctx, nn, &rt)).To(Succeed())
+			replicas := int32(3)
+			rt.Spec.Replicas = &replicas
+			Expect(k8sClient.Update(ctx, &rt)).To(Succeed())
+			reconcileAndFetch(ctx, r, nn)
+			Expect(listLeases(ctx, name)).To(HaveLen(3))
+
+			podName := name + "-pod-survivor"
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: testNamespace,
+					Labels:    SelectorLabels(name),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "runner", Image: "busybox"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, pod) }()
+
+			lease02Name := fmt.Sprintf(LeaseMemberNameFmt, name, 2)
+			var lease02 coordinationv1.Lease
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lease02Name, Namespace: testNamespace}, &lease02)).To(Succeed())
+			lease02.Spec.HolderIdentity = &podName
+			Expect(k8sClient.Update(ctx, &lease02)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, nn, &rt)).To(Succeed())
+			replicas = int32(1)
+			rt.Spec.Replicas = &replicas
+			Expect(k8sClient.Update(ctx, &rt)).To(Succeed())
+
+			reconcileAndFetch(ctx, r, nn)
+			leases := listLeases(ctx, name)
+
+			leaseNames := make([]string, len(leases))
+			for i := range leases {
+				leaseNames[i] = leases[i].Name
+			}
+			Expect(leaseNames).To(ContainElement(fmt.Sprintf(LeaseMemberNameFmt, name, 0)))
+			Expect(leaseNames).To(ContainElement(lease02Name))
+			Expect(leaseNames).NotTo(ContainElement(fmt.Sprintf(LeaseMemberNameFmt, name, 1)))
 		})
 	})
 

--- a/internal/controller/logicflowservice_controller.go
+++ b/internal/controller/logicflowservice_controller.go
@@ -406,6 +406,9 @@ func (r *LogicFlowServiceReconciler) resolveHost(ctx context.Context, svc *logic
 		}
 		return "", err
 	}
+	if len(ingress.Spec.Rules) > 0 && ingress.Spec.Rules[0].Host != "" {
+		return ingress.Spec.Rules[0].Host, nil
+	}
 	for _, lb := range ingress.Status.LoadBalancer.Ingress {
 		if lb.Hostname != "" {
 			return lb.Hostname, nil
@@ -413,9 +416,6 @@ func (r *LogicFlowServiceReconciler) resolveHost(ctx context.Context, svc *logic
 		if lb.IP != "" {
 			return lb.IP, nil
 		}
-	}
-	if len(ingress.Spec.Rules) > 0 && ingress.Spec.Rules[0].Host != "" {
-		return ingress.Spec.Rules[0].Host, nil
 	}
 	return "", nil
 }

--- a/internal/controller/quarkus_config.go
+++ b/internal/controller/quarkus_config.go
@@ -180,8 +180,6 @@ func WithFlowVolumeMounts(configMaps []corev1.ConfigMap) ContainerOption {
 	}
 }
 
-// WithDurableEnvVars returns a ContainerOption that sets durable lease env vars.
-// Filters user-provided duplicates for immutable env vars before adding operator values.
 // WithMetricsEnvVars works around quarkus-flow#854: @LookupIfProperty requires
 // explicit "true" even though docs say metrics auto-enable when Micrometer is present.
 func WithMetricsEnvVars() ContainerOption {
@@ -190,6 +188,7 @@ func WithMetricsEnvVars() ContainerOption {
 	}
 }
 
+// WithDurableEnvVars sets durable lease env vars, filtering user-provided duplicates for immutable vars.
 func WithDurableEnvVars(rt *logicv1.LogicFlowRuntime) ContainerOption {
 	return func(c *corev1ac.ContainerApplyConfiguration) {
 		immutable := map[string]bool{

--- a/internal/controller/quarkus_config.go
+++ b/internal/controller/quarkus_config.go
@@ -182,6 +182,14 @@ func WithFlowVolumeMounts(configMaps []corev1.ConfigMap) ContainerOption {
 
 // WithDurableEnvVars returns a ContainerOption that sets durable lease env vars.
 // Filters user-provided duplicates for immutable env vars before adding operator values.
+// WithMetricsEnvVars works around quarkus-flow#854: @LookupIfProperty requires
+// explicit "true" even though docs say metrics auto-enable when Micrometer is present.
+func WithMetricsEnvVars() ContainerOption {
+	return func(c *corev1ac.ContainerApplyConfiguration) {
+		c.WithEnv(envLiteral("QUARKUS_FLOW_METRICS_ENABLED", "true"))
+	}
+}
+
 func WithDurableEnvVars(rt *logicv1.LogicFlowRuntime) ContainerOption {
 	return func(c *corev1ac.ContainerApplyConfiguration) {
 		immutable := map[string]bool{
@@ -244,6 +252,7 @@ func apiKeyEnvVars(ak *logicv1.APIKeyAuthSpec) []*corev1ac.EnvVarApplyConfigurat
 		}
 		envs = append(envs,
 			envLiteral(prefix+"__ROLES", strings.Join(roles, ",")),
+			envLiteral(prefix+"__NAMESPACES", "*"),
 		)
 	}
 	return envs

--- a/internal/controller/quarkus_config_test.go
+++ b/internal/controller/quarkus_config_test.go
@@ -189,7 +189,7 @@ func TestSecurityEnvVars_APIKey(t *testing.T) {
 		}
 
 		envs := securityEnvVars(sec)
-		g.Expect(envs).To(gomega.HaveLen(3))
+		g.Expect(envs).To(gomega.HaveLen(4))
 
 		g.Expect(*envs[0].Value).To(gomega.Equal("api-key"))
 
@@ -199,6 +199,9 @@ func TestSecurityEnvVars_APIKey(t *testing.T) {
 
 		g.Expect(*envs[2].Name).To(gomega.Equal(`QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__"service-a"__ROLES`))
 		g.Expect(*envs[2].Value).To(gomega.Equal("flow-admin,flow-invoker"))
+
+		g.Expect(*envs[3].Name).To(gomega.Equal(`QUARKUS_FLOW_RUNNER_SECURITY_API_KEYS__"service-a"__NAMESPACES`))
+		g.Expect(*envs[3].Value).To(gomega.Equal("*"))
 	})
 
 	t.Run("multiple keys", func(t *testing.T) {
@@ -213,7 +216,7 @@ func TestSecurityEnvVars_APIKey(t *testing.T) {
 			},
 		}
 		envs := securityEnvVars(sec)
-		g.Expect(envs).To(gomega.HaveLen(5)) // type + 2*(secret+roles)
+		g.Expect(envs).To(gomega.HaveLen(7)) // type + 2*(secret+roles+namespaces)
 	})
 }
 

--- a/internal/controller/quarkus_constants.go
+++ b/internal/controller/quarkus_constants.go
@@ -25,5 +25,5 @@ const (
 	DurableComponentValue = "durable"
 	DurableManagedByValue = "quarkus-flow"
 
-	ClusterRoleDurable = "logic-flow-runtime-durable"
+	ClusterRoleDurable = "logic-operator-logic-flow-runtime-durable"
 )


### PR DESCRIPTION
## Summary

- **KIND local dev workflow**: `make kind-create/deploy/demo/undemo/delete` targets with ingress-nginx + cert-manager, updated README with quickstart
- **Fix reconcileLeases scale-down bug**: Operator was deleting leases by index regardless of holder — now checks running pods and skips deletion of held leases, preventing applicationId/lease mismatch and workflow orphaning
- **Enable Prometheus metrics**: Workaround for quarkus-flow#854 — sets `QUARKUS_FLOW_METRICS_ENABLED=true` on all runner deployments
- **Fix API-KEY NAMESPACES env var**: Add missing `__NAMESPACES` env var for API-KEY security (quarkus-flow#845)
- **Fix ClusterRoleDurable constant**: Include kustomize `logic-operator-` namePrefix
- **Fix persistence doc comments**: Replace legacy `data-index-service` references
- **Add sample configs**: `config/samples/authentication/` (API-KEY) and `config/samples/persistence/` (PostgreSQL + 3 replicas + sleepy workflow)

## Related quarkus-flow issues filed

- quarkiverse/quarkus-flow#845 — SmallRye Config `@WithDefault("*")` on `Set<String>` not working
- quarkiverse/quarkus-flow#850 — PoolMemberController must not acquire a lease that differs from applicationId
- quarkiverse/quarkus-flow#851 — Periodic scan for workflow instances in DB but not in memory
- quarkiverse/quarkus-flow#852 — Add `/q/flow/instances` REST endpoint
- quarkiverse/quarkus-flow#854 — `@LookupIfProperty` prevents auto-enabling metrics

## Test plan

- [x] All 74 controller unit tests pass
- [x] Exploratory test: 3-replica persistence deployment, fire sleepy workflows, scale 3→1 — surviving pod keeps its lease, orphaned workflows recovered on scale-up
- [x] Prometheus metrics verified: `quarkus_flow_workflow_started_total`, `quarkus_flow_instance_waiting`, `quarkus_flow_task_duration_seconds` all reporting after fix
- [x] API-KEY auth verified end-to-end: 401 unauthenticated, 401 wrong key, 202 correct bearer