### PR TITLE
chore: upgrade quarkus-flow-runner 0.15.1 → 1.0.0

### DIFF
--- a/internal/controller/integration_test.go
+++ b/internal/controller/integration_test.go
@@ -60,8 +60,8 @@ var _ = Describe("Cross-controller integration", func() {
 
 			vm := findVolumeMount(mainContainer(&dep), cmName)
 			Expect(vm).NotTo(BeNil(), "expected volumeMount for ConfigMap %s", cmName)
-			Expect(vm.MountPath).To(Equal(WorkflowMountPath + "/payment-processor.yaml"))
-			Expect(vm.SubPath).To(Equal("payment-processor.yaml"))
+			Expect(vm.MountPath).To(Equal(WorkflowMountPath + "/" + cmName))
+			Expect(vm.SubPath).To(BeEmpty())
 			Expect(vm.ReadOnly).To(BeTrue())
 
 			// Verify Runtime status

--- a/internal/controller/logicflowruntime_controller.go
+++ b/internal/controller/logicflowruntime_controller.go
@@ -119,7 +119,6 @@ func (r *LogicFlowRuntimeReconciler) applyDeployment(ctx context.Context, rt *lo
 		DefaultRunnerImage(rt.Spec.Persistence),
 		WithPersistenceEnvVars(rt.Spec.Persistence, rt.Namespace),
 		WithSecurityEnvVars(rt.Spec.Security),
-		WithMetricsEnvVars(),
 		DefaultProbes(),
 		WithFlowSourcePath(),
 		WithFlowVolumeMounts(configMaps),

--- a/internal/controller/logicflowruntime_controller_test.go
+++ b/internal/controller/logicflowruntime_controller_test.go
@@ -608,8 +608,8 @@ var _ = Describe("LogicFlowRuntime Controller", func() {
 
 			vm := findVolumeMount(c, cmName)
 			Expect(vm).NotTo(BeNil(), "volumeMount for ConfigMap not found")
-			Expect(vm.MountPath).To(Equal(WorkflowMountPath + "/payment-processor.yaml"))
-			Expect(vm.SubPath).To(Equal("payment-processor.yaml"))
+			Expect(vm.MountPath).To(Equal(WorkflowMountPath + "/" + cmName))
+			Expect(vm.SubPath).To(BeEmpty())
 			Expect(vm.ReadOnly).To(BeTrue())
 		})
 

--- a/internal/controller/quarkus_config.go
+++ b/internal/controller/quarkus_config.go
@@ -180,14 +180,6 @@ func WithFlowVolumeMounts(configMaps []corev1.ConfigMap) ContainerOption {
 	}
 }
 
-// WithMetricsEnvVars works around quarkus-flow#854: @LookupIfProperty requires
-// explicit "true" even though docs say metrics auto-enable when Micrometer is present.
-func WithMetricsEnvVars() ContainerOption {
-	return func(c *corev1ac.ContainerApplyConfiguration) {
-		c.WithEnv(envLiteral("QUARKUS_FLOW_METRICS_ENABLED", "true"))
-	}
-}
-
 // WithDurableEnvVars sets durable lease env vars, filtering user-provided duplicates for immutable vars.
 func WithDurableEnvVars(rt *logicv1.LogicFlowRuntime) ContainerOption {
 	return func(c *corev1ac.ContainerApplyConfiguration) {

--- a/internal/controller/quarkus_config.go
+++ b/internal/controller/quarkus_config.go
@@ -162,20 +162,18 @@ func WithFlowSourcePath() ContainerOption {
 	}
 }
 
-// WithFlowVolumeMounts returns a ContainerOption that adds a read-only VolumeMount per ConfigMap data key.
-// Uses subPath to mount each key as a direct file, avoiding ConfigMap symlink structures
-// that cause duplicate detection in the runner's Files.walk() scanner.
-// TODO(#22): revert to directory mounts once quarkiverse/quarkus-flow#835 is fixed.
+// WithFlowVolumeMounts returns a ContainerOption that mounts each ConfigMap as a read-only directory.
+// quarkus-flow 1.0.0 defaults followSymlinks=false — the runner's file scanner skips symlinks
+// and only processes regular files found by traversing the ConfigMap's timestamped data directory.
+// Directory mounts (unlike subPath) are automatically updated by the kubelet when ConfigMap
+// content changes, eliminating pod restarts for workflow definition updates.
 func WithFlowVolumeMounts(configMaps []corev1.ConfigMap) ContainerOption {
 	return func(c *corev1ac.ContainerApplyConfiguration) {
 		for i := range configMaps {
-			for key := range configMaps[i].Data {
-				c.WithVolumeMounts(corev1ac.VolumeMount().
-					WithName(configMaps[i].Name).
-					WithMountPath(WorkflowMountPath + "/" + key).
-					WithSubPath(key).
-					WithReadOnly(true))
-			}
+			c.WithVolumeMounts(corev1ac.VolumeMount().
+				WithName(configMaps[i].Name).
+				WithMountPath(WorkflowMountPath + "/" + configMaps[i].Name).
+				WithReadOnly(true))
 		}
 	}
 }

--- a/internal/controller/quarkus_config_test.go
+++ b/internal/controller/quarkus_config_test.go
@@ -264,6 +264,11 @@ func TestSecurityEnvVars_OIDC(t *testing.T) {
 	})
 }
 
+func TestQuarkusFlowVersion_IsOnePointO(t *testing.T) {
+	g := gomega.NewWithT(t)
+	g.Expect(QuarkusFlowVersion).To(gomega.Equal("1.0.0"))
+}
+
 func TestDefaultRunnerImage_AutoSelect(t *testing.T) {
 	g := gomega.NewWithT(t)
 	minimalExpected := fmt.Sprintf("%s/%s:%s-%s", QuarkusFlowRegistry, QuarkusFlowRunner, QuarkusFlowVersion, ImageVariantMinimal)

--- a/internal/controller/quarkus_config_test.go
+++ b/internal/controller/quarkus_config_test.go
@@ -602,3 +602,18 @@ func TestDurableDeploymentStrategy_MultiReplica(t *testing.T) {
 	g.Expect(s.RollingUpdate.MaxUnavailable.IntValue()).To(gomega.Equal(1))
 	g.Expect(s.RollingUpdate.MaxSurge.IntValue()).To(gomega.Equal(1))
 }
+
+func TestWithMetricsEnvVars_NotInjectedAfterUpgrade(t *testing.T) {
+	// Regression test: QUARKUS_FLOW_METRICS_ENABLED must NOT be injected.
+	// In quarkus-flow 1.0.0+ metrics auto-enable when Micrometer is present.
+	g := gomega.NewWithT(t)
+	c := corev1ac.Container().WithName("test")
+
+	// Apply all options that applyDeployment uses (excluding WithMetricsEnvVars)
+	WithFlowSourcePath()(c)
+
+	for _, e := range c.Env {
+		g.Expect(*e.Name).NotTo(gomega.Equal("QUARKUS_FLOW_METRICS_ENABLED"),
+			"QUARKUS_FLOW_METRICS_ENABLED must not be injected in 1.0.0+")
+	}
+}

--- a/internal/controller/quarkus_config_test.go
+++ b/internal/controller/quarkus_config_test.go
@@ -606,16 +606,18 @@ func TestDurableDeploymentStrategy_MultiReplica(t *testing.T) {
 }
 
 func TestWithMetricsEnvVars_NotInjectedAfterUpgrade(t *testing.T) {
-	// Regression test: QUARKUS_FLOW_METRICS_ENABLED must NOT be injected.
+	// Regression: QUARKUS_FLOW_METRICS_ENABLED must not appear in any env var
+	// emitted by the option builders used in applyDeployment.
 	// In quarkus-flow 1.0.0+ metrics auto-enable when Micrometer is present.
 	g := gomega.NewWithT(t)
 	c := corev1ac.Container().WithName("test")
 
-	// Apply all options that applyDeployment uses (excluding WithMetricsEnvVars)
+	WithSecurityEnvVars(logicv1.RuntimeSecuritySpec{})(c)
 	WithFlowSourcePath()(c)
+	WithFlowVolumeMounts(nil)(c)
 
 	for _, e := range c.Env {
 		g.Expect(*e.Name).NotTo(gomega.Equal("QUARKUS_FLOW_METRICS_ENABLED"),
-			"QUARKUS_FLOW_METRICS_ENABLED must not be injected in 1.0.0+")
+			"QUARKUS_FLOW_METRICS_ENABLED must not be injected in quarkus-flow 1.0.0+")
 	}
 }

--- a/internal/controller/quarkus_config_test.go
+++ b/internal/controller/quarkus_config_test.go
@@ -607,12 +607,17 @@ func TestDurableDeploymentStrategy_MultiReplica(t *testing.T) {
 
 func TestWithMetricsEnvVars_NotInjectedAfterUpgrade(t *testing.T) {
 	// Regression: QUARKUS_FLOW_METRICS_ENABLED must not appear in any env var
-	// emitted by the option builders used in applyDeployment.
+	// emitted by the full non-persistent option set used in applyDeployment.
 	// In quarkus-flow 1.0.0+ metrics auto-enable when Micrometer is present.
 	g := gomega.NewWithT(t)
 	c := corev1ac.Container().WithName("test")
 
+	// Mirror the exact option set applyDeployment uses for a non-persistent runtime
+	// (Persistence == nil, so WithDurableEnvVars is not appended).
+	DefaultRunnerImage(nil)(c)
+	WithPersistenceEnvVars(nil, "")(c)
 	WithSecurityEnvVars(logicv1.RuntimeSecuritySpec{})(c)
+	DefaultProbes()(c)
 	WithFlowSourcePath()(c)
 	WithFlowVolumeMounts(nil)(c)
 

--- a/internal/controller/quarkus_config_test.go
+++ b/internal/controller/quarkus_config_test.go
@@ -440,7 +440,7 @@ func testConfigMaps() []corev1.ConfigMap {
 	}
 }
 
-func TestWithFlowVolumeMounts_AddsOneMountPerConfigMapKey(t *testing.T) {
+func TestWithFlowVolumeMounts_AddsMountPerConfigMap(t *testing.T) {
 	g := gomega.NewWithT(t)
 	c := corev1ac.Container().WithName("test")
 	cms := testConfigMaps()
@@ -448,13 +448,15 @@ func TestWithFlowVolumeMounts_AddsOneMountPerConfigMapKey(t *testing.T) {
 	WithFlowVolumeMounts(cms)(c)
 
 	g.Expect(c.VolumeMounts).To(gomega.HaveLen(2))
+	// First ConfigMap: lfd-order-flow → mounted as directory
 	g.Expect(*c.VolumeMounts[0].Name).To(gomega.Equal("lfd-order-flow"))
-	g.Expect(*c.VolumeMounts[0].MountPath).To(gomega.Equal(WorkflowMountPath + "/order-flow.json"))
-	g.Expect(*c.VolumeMounts[0].SubPath).To(gomega.Equal("order-flow.json"))
+	g.Expect(*c.VolumeMounts[0].MountPath).To(gomega.Equal(WorkflowMountPath + "/lfd-order-flow"))
+	g.Expect(c.VolumeMounts[0].SubPath).To(gomega.BeNil())
 	g.Expect(*c.VolumeMounts[0].ReadOnly).To(gomega.BeTrue())
+	// Second ConfigMap: lfd-payment-processor → mounted as directory
 	g.Expect(*c.VolumeMounts[1].Name).To(gomega.Equal("lfd-payment-processor"))
-	g.Expect(*c.VolumeMounts[1].MountPath).To(gomega.Equal(WorkflowMountPath + "/payment-processor.json"))
-	g.Expect(*c.VolumeMounts[1].SubPath).To(gomega.Equal("payment-processor.json"))
+	g.Expect(*c.VolumeMounts[1].MountPath).To(gomega.Equal(WorkflowMountPath + "/lfd-payment-processor"))
+	g.Expect(c.VolumeMounts[1].SubPath).To(gomega.BeNil())
 	g.Expect(*c.VolumeMounts[1].ReadOnly).To(gomega.BeTrue())
 }
 

--- a/internal/controller/quarkus_constants.go
+++ b/internal/controller/quarkus_constants.go
@@ -7,7 +7,7 @@ import (
 const (
 	QuarkusFlowRegistry = logicv1.FlowRunnerRegistry
 	QuarkusFlowRunner   = logicv1.FlowRunnerImage
-	QuarkusFlowVersion  = "0.15.1"
+	QuarkusFlowVersion  = "1.0.0"
 
 	ImageVariantMinimal  = logicv1.ImageVariantMinimal
 	ImageVariantStandard = logicv1.ImageVariantStandard


### PR DESCRIPTION
## Summary

- Bumps `QuarkusFlowVersion` to `1.0.0` (single source of truth in `quarkus_constants.go`)
- Removes `WithMetricsEnvVars()` workaround for `quarkiverse/quarkus-flow#854` — Micrometer is now auto-enabled when on the classpath in 1.0.0
- Reverts ConfigMap volume mounts from per-key `subPath` to per-ConfigMap directory mounts — `quarkiverse/quarkus-flow#835` is fixed in 1.0.0 via `followSymlinks=false` in the runner's file scanner

## Why directory mounts matter

With `subPath` mounts (previous), Kubernetes does **not** propagate ConfigMap content changes to running pods — every workflow definition update required a pod restart. With directory mounts, the kubelet propagates changes automatically within ~1–2 min. This is a prerequisite for hot-reload of workflow definitions.

The runner logs on the upgraded pod confirm correct behaviour:
```
Flow Runner: Loading workflows from filesystem: /deployments/workflows
Flow Runner: Workflow Definitions loaded: [default:hello-world:1.0.0, default:sleepy-workflow:1.0.0]
```
No duplicate detection errors, Micrometer auto-enabled, file watcher active.

## Test plan

- [x] `make test` — 83 unit/integration specs passing
- [x] `make test-e2e` — 22/22 e2e specs passing in fresh KIND cluster
- [x] `make kind-deploy` + `make kind-demo` — runner pod starts with directory mounts, both workflows load correctly from `/deployments/workflows`

## Migration notes

The `quarkus-flow` 0.15.1 → 1.0.0 migration guide is at `docs/modules/ROOT/pages/migration-0.15-to-0.16.adoc` in the quarkiverse/quarkus-flow repo. Breaking changes in the operator's domain:

| Change | Operator impact |
|--------|----------------|
| `QUARKUS_FLOW_RUNNER_SECURITY_TYPE` now required | Already handled — always injected for all security modes |
| Micrometer auto-enabled | Removed explicit `QUARKUS_FLOW_METRICS_ENABLED=true` injection |
| `followSymlinks=false` default | Reverted to directory mounts; runner finds regular files via `..date.../key` traversal |