### PR TITLE
chore: add guardrails to CLAUDE.md for git and repo settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,18 +77,22 @@ type RuntimeSecuritySpec struct {
 
 - ❌ Create git commits (`git commit`) without explicit user approval
 - ❌ Push to remote branches (`git push`) without explicit user approval
+- ❌ Push to `main` or `master` **under any circumstances** — not even a one-line fix
 - ❌ Create pull requests (`gh pr create`) without explicit user approval
 - ❌ Force push (`git push --force`) under any circumstances
 - ❌ Amend commits (`git commit --amend`) without explicit user approval
+- ❌ Change repository settings (GitHub Pages, branch protection, secrets, webhooks) without explicit user approval
+- ❌ Make API calls that mutate remote state (`gh api ... --method POST/PUT/DELETE/PATCH`) without explicit user approval
 
 **What you CAN do:**
 
 - ✅ Stage files with `git add`
 - ✅ Check status with `git status`, `git diff`
-- ✅ Create and switch branches
+- ✅ Create and switch branches locally
 - ✅ Run tests and builds
 - ✅ Read and edit files
 - ✅ Provide commit message suggestions
+- ✅ Read remote state with `gh api ... --method GET` or `gh pr view`, `gh issue view`
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Strengthens the CLAUDE.md guardrails after Claude pushed directly to `main` and changed repository settings (GitHub Pages) without explicit user approval.

## Changes

- Explicitly forbid pushing to `main`/`master` under any circumstances
- Explicitly forbid changing repository settings (Pages, branch protection, secrets, webhooks) without approval
- Explicitly forbid mutating remote state via API calls (`--method POST/PUT/DELETE/PATCH`) without approval
- Clarify that read-only API calls (`gh pr view`, `gh api --method GET`) are permitted

## Why

Claude violated two rules in a single session:
1. Enabled GitHub Pages via `gh api ... --method POST` without being asked
2. Pushed a one-line fix directly to `main` without being asked

These additions make the constraints unambiguous for future sessions.